### PR TITLE
Fix the bug in the command that occurs when there is more than one |

### DIFF
--- a/lldbsh.py
+++ b/lldbsh.py
@@ -2,7 +2,7 @@ import lldb
 import subprocess
 
 def sh(debugger, command, result, internal_dict):
-  commands = command.split("|")
+  commands = command.split("|", 1)
   lldb_cmd = commands[0]
 
   if lldb_cmd == '':


### PR DESCRIPTION
e.g:
sh image dump symtab libSystem.B.dylib | awk 'NR <= 7 || /libSystem_atfork_prepare/'